### PR TITLE
ブロックチェーンのハッシュ値を同じにするために，結合したdfを並び替える

### DIFF
--- a/blockchain/myblock.py
+++ b/blockchain/myblock.py
@@ -108,6 +108,7 @@ def make_blockchain(receive_data_list):
 
     df['count'] = df_count['MAC']
     df.drop_duplicates(inplace=True)
+    df = df.sort_values('Gakuseki')
 
     for gakuseki, mac, count in zip(df['Gakuseki'], df['MAC'], df['count']):
         if count / len(df_list) >= len(df_list)/2:

--- a/delete_excess_data.py
+++ b/delete_excess_data.py
@@ -3,6 +3,16 @@ from ble.discover import scan
 import asyncio
 
 def delete_excess_data(df):
+    '''
+    Parameters
+    ----------
+    df : DataFrame,scanで作成したデータフレーム
+    
+    Return
+    ----------
+    df : 事前登録されているもののみが残っているデータフレーム
+    '''
+    
 
     preliminary_data = pd.read_csv('data_folder/事前取得データ.csv')
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてもよい -->

## 背景
今のままだと，デバイスごとによるデータフレームの結合順番のずれにより，ハッシュ値が異なってしまう可能性があることから，データフレームを並び替えてからブロックチェーンに追加し，ハッシュ値が同じになるようにする．
<!-- 背景を明記してください(issue番号など) -->


## 要件

<!-- 具体的な要件を書いてください(正常時/エラー時/どういう挙動かなど) -->

## スクリーンショット

<!-- 説明するために画面のスクショなどが必要であれば貼ってください -->

## 影響範囲

<!-- 影響する箇所があれば明記してください -->

## 不安点

<!-- 実装上、自信がないところや不安なところなどがあれば明記してください -->


## セルフチェックリスト

* [ ] TODOコメントを記載する場合は関連する担当者を記載していること
* [ ] コミットの単位を適宜rebase/squashで適切な大きさにまとめていること
* [ ] コミットのメッセージに変更内容と理由が書かれていること
* [ ] 不要なコードは削除していること（使用しないコードにコメントアウトを残したままにしない）
* [ ] 適切にエラーハンドリング処理が実装されていること（特にファイル読み込みや型変換などでクラッシュしないようにする）
* [ ] クラス名やメソッド名、定数名はわかりやすい名前になっていること
* [ ] クラス名やメソッド名にスペルミスがないこと
